### PR TITLE
Fixed the issue that window switching keys were written incorrectly.

### DIFF
--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -44,19 +44,19 @@ local keymaps = {
     --   desc = "Enter insert mode",
     -- },
 
-    ["C-j"] = {
+    ["<C-j>"] = {
       cmd = "<C-w>j",
       desc = "Go to upper window",
     },
-    ["C-k"] = {
+    ["<C-k>"] = {
       cmd = "<C-w>k",
       desc = "Go to lower window",
     },
-    ["C-h"] = {
+    ["<C-h>"] = {
       cmd = "<C-w>h",
       desc = "Go to left window",
     },
-    ["C-l"] = {
+    ["<C-l>"] = {
       cmd = "<C-w>l",
       desc = "Go to right window",
     },


### PR DESCRIPTION
I'm learning to configure nvim, thanks to this repository. 

During my use, I found that the shortcut keys for window switching did not take effect. After checking the keymaps.lua file, I found that it seemed that there was a typo here.