### PR TITLE
feat: enables working java test debugging

### DIFF
--- a/core/autocommands.lua
+++ b/core/autocommands.lua
@@ -174,7 +174,14 @@ autocmd("FileType", {
     local bufnr = vim.api.nvim_get_current_buf()
 
     local java_debug_path = vim.fn.stdpath "data" .. "/mason/packages/java-debug-adapter/"
+    local java_test_path = vim.fn.stdpath "data" .. "/mason/packages/java-test/"
     local jdtls_path = vim.fn.stdpath "data" .. "/mason/packages/jdtls/"
+
+    local bundles = {
+      vim.fn.glob(java_debug_path .. "extension/server/com.microsoft.java.debug.plugin-*.jar", 1),
+    };
+    vim.list_extend(bundles, vim.split(vim.fn.glob(java_test_path .. "extension/server/*.jar", 1), "\n"))
+
     -- NOTE: Decrease the amount of files to improve speed(Experimental).
     -- INFO: It's annoying to edit the version again and again.
     local equinox_path = vim.split(vim.fn.glob(vim.fn.stdpath "data" .. "/mason/packages/jdtls/plugins/*jar"), "\n")
@@ -245,9 +252,7 @@ autocmd("FileType", {
       -- One dedicated LSP server & client will be started per unique root_dir
       root_dir = require("jdtls.setup").find_root(root_markers),
       init_options = {
-        bundles = {
-          vim.fn.glob(java_debug_path .. "extension/server/com.microsoft.java.debug.plugin-*.jar", 1),
-        },
+        bundles = bundles,
       },
       settings = {
         eclipse = {
@@ -296,6 +301,8 @@ autocmd("FileType", {
     command! -buffer JdtJol lua require('jdtls').jol()
     command! -buffer JdtBytecode lua require('jdtls').javap()
     command! -buffer JdtJshell lua require('jdtls').jshell()
+    command! -buffer JavaTestCurrentClass lua require('jdtls').test_class()
+    command! -buffer JavaTestNearestMethod lua require('jdtls').test_nearest_method()
     ]]
 
     -- This starts a new client & server,

--- a/plugins/dap/settings/java-debug.lua
+++ b/plugins/dap/settings/java-debug.lua
@@ -2,6 +2,16 @@
 local dap = require "dap"
 dap.configurations.java = {
   {
+    name = "Launch Java",
     javaExec = "java",
+    request = "launch",
+    type = "java",
+  },
+  {
+    type = 'java',
+    request = 'attach',
+    name = "Debug (Attach) - Remote",
+    hostName = "127.0.0.1",
+    port = 5005,
   },
 }

--- a/plugins/lsp/init.lua
+++ b/plugins/lsp/init.lua
@@ -90,6 +90,12 @@ return {
           require "custom.plugins.lsp.mason"
         end,
       },
+      opts = {
+        registries = {
+          "github:nvim-java/mason-registry",
+          "github:mason-org/mason-registry",
+        },
+      },
     },
     -- Improve Other LSP Functionalities
     {


### PR DESCRIPTION
This change updates the jdtls config to properly include the java-test packages imported via Mason. A Mason repository is also introduced for java-test since the java-test package in the default repo is borked as I understand it. Lastly, setups up default DAP configs for Java so that users no longer see "nil" as the default launch configuration.