### PR TITLE
fix(marks): wrong trigger event

### DIFF
--- a/lua/plugins/marks.lua
+++ b/lua/plugins/marks.lua
@@ -1,6 +1,6 @@
 -- NOTE: Show Marks
 return {
   "chentoast/marks.nvim",
-  event = "User FilPost",
+  event = "User FilePost",
   opts = {},
 }


### PR DESCRIPTION
Hi. There is a typo issue in the trigger event of marks plugin which makes it couldn't start.

But I don't know how to fix the rest of this issue 🫠 It only works with some files (like..., not script files or sth)

---

It works with markdown, txt...
![image](https://github.com/Alexis12119/nvim-config/assets/86353526/84b685fd-a239-43cd-adbb-6be43d730777)

Doesn't work with script file (only make the line number white)
![image](https://github.com/Alexis12119/nvim-config/assets/86353526/30ec1296-82be-40f2-bebf-902cb4046308)
