### PR TITLE
feat(wakatime): conditionally enable

### DIFF
--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,6 +2,6 @@ return {
   {
     "wakatime/vim-wakatime",
     event = "VeryLazy",
-    enable = vim.fn.executable "wakatime" and vim.fn.filereadable "~/.wakatime.cfg",
+    enabled = vim.fn.executable "wakatime" and vim.fn.filereadable "~/.wakatime.cfg",
   },
 }

--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,7 +2,6 @@ return {
   {
     "wakatime/vim-wakatime",
     event = "VeryLazy",
-    enabled = (vim.fn.executable "wakatime" or vim.fn.executable "wakatime-cli")
-      and vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
+    enabled = vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
   },
 }

--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,6 +2,6 @@ return {
   {
     "wakatime/vim-wakatime",
     event = "VeryLazy",
-    enabled = vim.fn.executable "wakatime" and vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
+    enabled = vim.fn.executable "wakatime" == 1 and vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
   },
 }

--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,6 +2,7 @@ return {
   {
     "wakatime/vim-wakatime",
     event = "VeryLazy",
-    enabled = vim.fn.executable "wakatime" == 1 and vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
+    enabled = (vim.fn.executable "wakatime" or vim.fn.executable "wakatime-cli")
+      and vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
   },
 }

--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,5 +2,6 @@ return {
   {
     "wakatime/vim-wakatime",
     event = "VeryLazy",
+    enable = vim.fn.executable "wakatime" and vim.fn.filereadable "~/.wakatime.cfg",
   },
 }

--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,6 +2,6 @@ return {
   {
     "wakatime/vim-wakatime",
     event = "VeryLazy",
-    enabled = vim.fn.executable "wakatime" and vim.fn.filereadable "~/.wakatime.cfg",
+    enabled = vim.fn.executable "wakatime" and vim.fn.filereadable(vim.fn.getenv "HOME" .. "/.wakatime.cfg"),
   },
 }


### PR DESCRIPTION
Hi, I have added a condition to enable `wakatime` if only the `wakatime` cli command exists, and `~/.wakatime.conf` exists.

Could you please check it and test it before merging? Because I don't see the document about `vim.fn.executable`.