### PR TITLE
feat(`telescope`): improve `file_ignore_patterns`

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -112,7 +112,7 @@ return {
           ["<C-q>"] = require("trouble.sources.telescope").open,
         },
       },
-      file_ignore_patterns = { "node_modules", ".git" },
+      file_ignore_patterns = { "node_modules/", "node_modules\\", ".git/", ".git\\" },
     },
   },
 }

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -112,7 +112,7 @@ return {
           ["<C-q>"] = require("trouble.sources.telescope").open,
         },
       },
-      file_ignore_patterns = { "node_modules/", "node_modules\\", ".git/", ".git\\" },
+      file_ignore_patterns = { "node_modules", ".git/" },
     },
   },
 }


### PR DESCRIPTION
this will ignore `node_module` and `.git` folders in across OSes (Windows, Linux, Mac...) (I guess)

without this commit, it will ignore some folder that shouldn't be ignored (ex: `.github/` on Windows)

Edit: I think the reason it ignores is Windows use `\` as path separator.
Edit: Here is the [`telescope.defaults.file_ignore_patterns`](https://github.com/nvim-telescope/telescope.nvim/blob/f12b15e1b3a33524eb06a1ae7bc852fb1fd92197/doc/telescope.txt#L667C1-L686C21) doc.