### PR TITLE
feat(`filetypes`): improve recognition of `ghaction` ft

### DIFF
--- a/lua/core/filetypes.lua
+++ b/lua/core/filetypes.lua
@@ -3,8 +3,8 @@ vim.filetype.add {
   extension = {
     ["templ"] = "templ",
   },
-    pattern = {
-    [".*/.github/workflows/.*%.yml"] = "yaml.ghaction",
-    [".*/.github/workflows/.*%.yaml"] = "yaml.ghaction",
+  pattern = {
+    [".*%.github/workflows/.*%.yml"] = "yaml.ghaction",
+    [".*%.github/workflows/.*%.yaml"] = "yaml.ghaction",
   },
 }


### PR DESCRIPTION
Just an improvement of `ghaction` filetype recognition. 🫠

```diff
-    [".*/.github/workflows/.*%.yml"] = "yaml.ghaction",
-    [".*/.github/workflows/.*%.yaml"] = "yaml.ghaction",
+    [".*%.github/workflows/.*%.yml"] = "yaml.ghaction",
+    [".*%.github/workflows/.*%.yaml"] = "yaml.ghaction",
```

Explain:

- I removed the first `/` because some files don't have the full file path (I don't know why 😅). Just see these two images.
  >  ![image](https://github.com/Alexis12119/nvim-config/assets/86353526/acb4e71e-3a74-41b8-8c4b-3f15ef2afdb8)
  > ![image](https://github.com/Alexis12119/nvim-config/assets/86353526/570be035-5277-4f99-b3dc-1f553682b04a)
- I add `%` before `.` in `.github` because the `.` should be escaped (`%` mean `\`)

---

Also, I don't know why there's a diff before `  pattern` in line 6. But, nah I think it's harmless. :))