### PR TITLE
feat(nvchad): add default value to get_header

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -16,7 +16,7 @@ local function get_venv(variable)
   return venv
 end
 
-local function get_header()
+local function get_header(default)
   if vim.g.random_header then
     local headerNames = {}
     for name, _ in pairs(headers) do
@@ -27,7 +27,8 @@ local function get_header()
     local randomHeader = headers[randomName]
     return randomHeader
   else
-    return headers["nvchad"]
+    local name = (default == nil or default == "") and "nvchad" or default
+    return headers[name]
   end
 end
 
@@ -247,14 +248,14 @@ M.ui = {
 
   nvdash = {
     load_on_startup = false,
-    header = get_header(),
+    header = get_header "nvchad",
     buttons = {
-      { txt = "  Find File", keys = "Spc f f", cmd = "Telescope find_files" },
-      { txt = "󰈚  Recent Files", keys = "Spc f r", cmd = "Telescope oldfiles" },
-      { txt = "󰈭  Find Word", keys = "Spc f w", cmd = "Telescope live_grep" },
-      { txt = "  Find Projects", keys = "Spc f p", cmd = "Telescope projects" },
-      { txt = "  Themes", keys = "Spc f t", cmd = "Telescope themes" },
-      { txt = "  Mappings", keys = "Spc n c", cmd = "NvCheatsheet" },
+      { "  Find File", "Spc f f", "Telescope find_files" },
+      { "󰈚  Recent Files", "Spc f r", "Telescope oldfiles" },
+      { "󰈭  Find Word", "Spc f w", "Telescope live_grep" },
+      { "  Find Projects", "Spc f p", "Telescope projects" },
+      { "  Themes", "Spc f t", "Telescope themes" },
+      { "  Mappings", "Spc n c", "NvCheatsheet" },
     },
   },
 }


### PR DESCRIPTION
Hi :wave: 
This is a small improvement/fix for the nvdash.
I've found that having named variables in the buttons tables results in an error thrown from nvdash, so I've removed them.

Also added a default argument to `get_header`, which to me seemed like a more natural place to configure the non-random header value. This way, if one wants to update the default header, instead of updating the function body - they would update the value at the call site.