### PR TITLE
feat(dap:) use delve for debugging Go and replace neotest-go adapter with neotest-golang

### DIFF
--- a/lua/plugins/neotest.lua
+++ b/lua/plugins/neotest.lua
@@ -37,12 +37,27 @@ return {
   end,
   dependencies = {
     "nvim-neotest/neotest-python",
-    "nvim-neotest/neotest-go",
+    -- "nvim-neotest/neotest-go", -- does not support monorepos where go.mod is not in root
     -- "marilari88/neotest-vitest",
     -- "nvim-neotest/neotest-jest",
     -- "rouge8/neotest-rust",
     -- "rcasia/neotest-java",
     "nvim-treesitter/nvim-treesitter",
+    -- extra dependencies for golang debugging with suppport for monorepos
+    -- ref https://github.com/fredrikaverpil/neotest-golang/?tab=readme-ov-file#example-configuration-debugging
+    "nvim-neotest/nvim-nio",
+    "nvim-lua/plenary.nvim",
+    {
+      "fredrikaverpil/neotest-golang", -- Installation
+      dependencies = {
+        {
+          "leoluz/nvim-dap-go",
+          init = function()
+            require("dap-go").setup()
+          end,
+        },
+      },
+    },
   },
   config = function()
     require("neotest").setup {
@@ -50,7 +65,7 @@ return {
         require "neotest-python" {
           runner = "pytest",
         },
-        require "neotest-go",
+        require "neotest-golang", -- Registration
       },
     }
   end,


### PR DESCRIPTION
Tried to setup DAP for go following nvim-dap documentation with using delve directly instead of relying on two tools (go-debug-adapter + delve), as described in https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go-using-delve-directly

However, I was struggling to get DAP working and was getting `"Error on launch: Failed to launch"` errors all the time, when I discovered (via dap-ui) that the defaults of `nvim-dap-go` expects `go.mod` to be in the root of the project.

At the same time, the "native" neotest adapter for go seems to have the same behavior and does not seem to support projects where go.mod is not in the root.

This was originally described here
https://github.com/leoluz/nvim-dap-go/issues/80#issuecomment-2082055692, and there's an open issue for this in nvim-dap-go: https://github.com/leoluz/nvim-dap-go/issues/85

There is, however, another adapter for go - `fredrikaverpil/neotest-golang` - which seems to be more flexible and does support projects where go.mod is not in the root.

After replacing the adapter and adding configurations as per https://github.com/fredrikaverpil/neotest-golang/?tab=readme-ov-file#example-configuration-debugging, I was finally able to get DAP working for golang tests.