### PR TITLE
fix(lsp): eslint settings table

### DIFF
--- a/lua/plugins/lsp/settings/eslint.lua
+++ b/lua/plugins/lsp/settings/eslint.lua
@@ -1,14 +1,34 @@
 return {
   settings = {
-    eslint = {
-      format = {
+    codeAction = {
+      disableRuleComment = {
+        enable = true,
+        location = "separateLine",
+      },
+      showDocumentation = {
         enable = true,
       },
-      rules = {
-        customizations = {
-          -- Your Rules
-        },
-      },
+    },
+    codeActionOnSave = {
+      enable = false,
+      mode = "all",
+    },
+    experimental = {
+      useFlatConfig = true,
+    },
+    format = true,
+    nodePath = "",
+    onIgnoredFiles = "off",
+    problems = {
+      shortenToSingleLine = false,
+    },
+    quiet = false,
+    rulesCustomizations = {},
+    run = "onType",
+    useESLintClass = false,
+    validate = "on",
+    workingDirectory = {
+      mode = "location",
     },
   },
 }


### PR DESCRIPTION
It seems that the table had incorrect (outdated?) structure.

I've pretty much copy-pasted it from https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md\#eslint, and kept all defaults (not sure if you want to change anything from defaults), with exception of enabling usage of flat config files.

I've tested e.g. enabling and disabling eslint code-actions, and the settings are picked fine up now.