### PR TITLE
fix: load option before lazy

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,6 @@
 require "core.globals"
 require "core.env"
+require "options"
 
 if vim.version().minor >= 11 then
   vim.tbl_add_reverse_lookup = function(tbl)
@@ -39,7 +40,6 @@ for _, v in ipairs(vim.fn.readdir(vim.g.base46_cache)) do
   dofile(vim.g.base46_cache .. v)
 end
 
-require "options"
 require "nvchad.autocmds"
 require "core.commands"
 require "core.autocommands"


### PR DESCRIPTION
Every time there is/are new plugin(s), it will trigger installing plugin. And option cannot be set in Lazy's buffer

Lazyvim load option first also (but I cannot find where it require the option file :))
<https://github.com/LazyVim/LazyVim/blob/4aff0063a42bbc499cfa03feb6e58d4339c0950d/lua/lazyvim/config/init.lua#L20>